### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,8 @@ The module assumes the following paths to the hosts file
 
 In order to avoid conflicts with other IP addresses you may assign manually, the module only uses IP addresses in the range `127.127.0.1` to `127.127.255.255`.
 
-It detects the highest used IP address in that range and increase that by 1. That gives you 255 x 255 = 65.025 IP addresses to use.  This means each server can use port 80 since you can bind more than one server to the same port so long as it's a different IP.  This gets rid of those random ports for local development.  To set port 80 as the default port for all servers, run the following:
-```bash
-CommandBox> config set server.defaults.web.http.port=80
-```
+It detects the highest used IP address in that range and increase that by 1. That gives you 255 x 255 = 65.025 IP addresses to use.  This means each server can use port 80 since you can bind more than one server to the same port so long as it's a different IP.  This gets rid of those random ports for local development.  
+
 Please note, this will NOT work if you have another web server such as Apache that has been configured to listen to port 80 on all IPs ( `*.80` ).  You can troubleshoot what other processes are listening to ports with the `netstat` command.
 ```bash
 # On Windows


### PR DESCRIPTION
Well crap-- turns out HTTP port doesn't look a the global defaults.  I remember removing that a while back thinking to myself that noone would ever want all servers to be on the same port since it wouldn't work.  Wrong!!  I'll make it so this works in the next version of CommandBox, but in the meantime we shouldn't tell people do use it!