### PR TITLE
Improve line break handling

### DIFF
--- a/models/HostupdaterService.cfc
+++ b/models/HostupdaterService.cfc
@@ -19,16 +19,15 @@ component accessors="true" singleton {
 			// remove all lines that already contain either the server id or the host name
 			// that way we can make sure that the hosts file doesn't grow indefinitely upon
 			// changing the host name for an existing server
-			hosts =  removeMatchingLines( hosts, [arguments.hostname,arguments.server_id] )
-					.toList( server.separator.line ); // concatenate the array
+			hosts =  removeMatchingLines( hosts, [arguments.hostname,arguments.server_id] );
 
 			variables.printBuffer.greenLine( "Adding host '#arguments.hostname#' to your hosts file!" ).toConsole(); 
 			var new_ip = getNewIP( hosts );
-			hosts&="#server.separator.line##new_ip#	#arguments.hostname# ## CommandBox: Server #arguments.server_id# #dateTimeFormat( now(), 'yyyy-mm-dd HH:nn:ss' )#" // add the line for the new host entry
-					
-			saveHostsFile( hostsFile, hosts );
-				
+			// add the line for the new host entry
+			hosts.append( "#server.separator.line##new_ip#	#arguments.hostname# ## CommandBox: Server #arguments.server_id# #dateTimeFormat( now(), 'yyyy-mm-dd HH:nn:ss' )#" );
 			
+			// concatenate the array
+			saveHostsFile( hostsFile, hosts.toList( server.separator.line ) );			
 		}
 
 		return;

--- a/models/HostupdaterService.cfc
+++ b/models/HostupdaterService.cfc
@@ -24,7 +24,7 @@ component accessors="true" singleton {
 			variables.printBuffer.greenLine( "Adding host '#arguments.hostname#' to your hosts file!" ).toConsole(); 
 			var new_ip = getNewIP( hosts.toList( server.separator.line ) );
 			// add the line for the new host entry
-			hosts.append( "#server.separator.line##new_ip#	#arguments.hostname# ## CommandBox: Server #arguments.server_id# #dateTimeFormat( now(), 'yyyy-mm-dd HH:nn:ss' )#" );
+			hosts.append( "#new_ip#	#arguments.hostname# ## CommandBox: Server #arguments.server_id# #dateTimeFormat( now(), 'yyyy-mm-dd HH:nn:ss' )#" );
 			
 			// concatenate the array
 			saveHostsFile( hostsFile, hosts.toList( server.separator.line ) );			

--- a/models/HostupdaterService.cfc
+++ b/models/HostupdaterService.cfc
@@ -27,7 +27,10 @@ component accessors="true" singleton {
 			hosts.append( "#new_ip#	#arguments.hostname# ## CommandBox: Server #arguments.server_id# #dateTimeFormat( now(), 'yyyy-mm-dd HH:nn:ss' )#" );
 			
 			// concatenate the array
-			saveHostsFile( hostsFile, hosts.toList( server.separator.line ) );			
+			saveHostsFile( hostsFile, hosts.toList( server.separator.line ) );
+			
+			// Give the OS a chance to write the file
+			sleep( 300 );
 		}
 
 		return;

--- a/models/HostupdaterService.cfc
+++ b/models/HostupdaterService.cfc
@@ -22,7 +22,7 @@ component accessors="true" singleton {
 			hosts =  removeMatchingLines( hosts, [arguments.hostname,arguments.server_id] );
 
 			variables.printBuffer.greenLine( "Adding host '#arguments.hostname#' to your hosts file!" ).toConsole(); 
-			var new_ip = getNewIP( hosts );
+			var new_ip = getNewIP( hosts.toList( server.separator.line ) );
 			// add the line for the new host entry
 			hosts.append( "#server.separator.line##new_ip#	#arguments.hostname# ## CommandBox: Server #arguments.server_id# #dateTimeFormat( now(), 'yyyy-mm-dd HH:nn:ss' )#" );
 			

--- a/models/HostupdaterService.cfc
+++ b/models/HostupdaterService.cfc
@@ -24,7 +24,7 @@ component accessors="true" singleton {
 
 			variables.printBuffer.greenLine( "Adding host '#arguments.hostname#' to your hosts file!" ).toConsole(); 
 			var new_ip = getNewIP( hosts );
-			hosts=hosts.listAppend( "#server.separator.line##new_ip#	#arguments.hostname# ## CommandBox: Server #arguments.server_id# #dateTimeFormat( now(), 'yyyy-mm-dd HH:nn:ss' )#", server.separator.line ) // add the line for the new host entry
+			hosts&="#server.separator.line##new_ip#	#arguments.hostname# ## CommandBox: Server #arguments.server_id# #dateTimeFormat( now(), 'yyyy-mm-dd HH:nn:ss' )#" // add the line for the new host entry
 					
 			saveHostsFile( hostsFile, hosts );
 				


### PR DESCRIPTION
On windows, the line separator is two characters.  When you pass a delimiter of two characters into `listAppend()` it only uses the first one and not the second one.  That means on Windows, the line breaks weren't correct.  In addition you were turning it back into a list for some reason prior to appending the new line which was just more work. Keep it as an array until you're done fiddling with it, then concat it all back to a list prior to writing.  And on a side note, for whatever reason, `arrayToList()` _DOES_ include both delimiters.