### PR TITLE
Allow host name aliases

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -10,8 +10,16 @@ component accessors=true {
 						arguments.interceptData.serverDetails.serverJSON.web.host ?:			// host provided in server.json?
 						wirebox.getInstance( 'ServerService' ).getDefaultServerJSON().web.host; // if nothing was provided, use default (127.0.0.1)
 
-		if (isArray(hostname)) {
-			hostname = arrayToList(hostname, " ");
+		var hostAlias = arguments.interceptData.serverProps.hostAlias			  		?: 			// host provided on the command line?
+						arguments.interceptData.serverDetails.serverJSON.web.hostAlias 	?:			// host provided in server.json?
+						''; // No alias was provided.
+
+		if (isArray(hostAlias) && !arrayIsEmpty(hostAlias)) {
+			hostAlias = arrayToList(hostAlias, " ");
+		}
+
+		if (len(hostAlias) GT 0) {
+			hostname &= " " & hostAlias;
 		}
 
 		wirebox.getInstance( 'hostupdaterService@commandbox-hostupdater' ).checkIP( arguments.interceptData.serverDetails.serverInfo.id, hostname );

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -4,11 +4,15 @@ component accessors=true {
 		return;
 	}
 
-	
+
 	public void function preServerStart( interceptData ) {
 		var hostname = 	arguments.interceptData.serverProps.host 				  ?: 			// host provided on the command line?
 						arguments.interceptData.serverDetails.serverJSON.web.host ?:			// host provided in server.json?
 						wirebox.getInstance( 'ServerService' ).getDefaultServerJSON().web.host; // if nothing was provided, use default (127.0.0.1)
+
+		if (isArray(hostname)) {
+			hostname = arrayToList(hostname, " ");
+		}
 
 		wirebox.getInstance( 'hostupdaterService@commandbox-hostupdater' ).checkIP( arguments.interceptData.serverDetails.serverInfo.id, hostname );
 
@@ -16,7 +20,7 @@ component accessors=true {
 	}
 
 	public void function postServerForget( interceptData ) {
-		
+
 		wirebox.getInstance( 'hostupdaterService@commandbox-hostupdater' ).forgetServer( arguments.interceptData.serverInfo.id );
 
 		return;

--- a/README.md
+++ b/README.md
@@ -34,14 +34,18 @@ The module will first remove any host names that you previously assigned *to the
 
 Often your applicaiton will require multiple hosts to function correctly. This can be the case with multi-tenant and/or multi-portal applcations.
 
-Edit your `server.json` to use an array of hostnames.
+Pass an alias via the CLI:
+```bash
+CommandBox> server set web.hostAlias=www.myproject.local
+```
+
+To use more than one alias, edit your `server.json` to use an array of hostnames.
 
 ```bash
-
 {
 	"web": {
-		"host": [
-			"project.local",
+		"host": "project.local",
+		"hostAlias": [
 			"www.project.local",
 			"portalA.project.local",
 			"portalB.project.local"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ You can install the module from within CommandBox by executing the install comma
 CommandBox> install commandbox-hostupdater
 ```
 
+To uninstall the module, switch to the installation folder in Commandbox and run the uninstall command:
+```bash
+CommandBox> #expandPath /commandbox | cd
+CommandBox> list
+CommandBox> uninstall commandbox-hostupdater
+```
+
 ### Usage
 *In order for the module to be able to modify your hosts file you need to start CommandBox with administrator privileges.*
 *For Mac and Linux users that means you have to start CommandBox with `sudo box`*
@@ -23,9 +30,30 @@ CommandBox> server start host=myproject.local port=80
 ```
 The module will first remove any host names that you previously assigned *to the same server* and then add the host name (here 'myproject.local') to your hosts file. All entries added by the module will be marked with a comment `# CommandBox <Server-ID> <current timestamp>`.
 
+#### Assigning Multiple Hosts
+
+Often your applicaiton will require multiple hosts to function correctly. This can be the case with multi-tenant and/or multi-portal applcations.
+
+Edit your `server.json` to use an array of hostnames.
+
+```bash
+
+{
+	"web": {
+		"host": [
+			"project.local",
+			"www.project.local",
+			"portalA.project.local",
+			"portalB.project.local"
+		]
+	}
+}
+```
+The module will concert this array into space-delimited list and make a single entry in the hosts file as previously described.
+
 ### Location of the hosts file
 
-The module assumes the following paths to the hosts file 
+The module assumes the following paths to the hosts file
 
 * **Windows** - `C:\Windows\System32\drivers\etc\hosts`
 * **Linux** - `/etc/hosts`
@@ -35,7 +63,7 @@ The module assumes the following paths to the hosts file
 
 In order to avoid conflicts with other IP addresses you may assign manually, the module only uses IP addresses in the range `127.127.0.1` to `127.127.255.255`.
 
-It detects the highest used IP address in that range and increase that by 1. That gives you 255 x 255 = 65.025 IP addresses to use.  This means each server can use port 80 since you can bind more than one server to the same port so long as it's a different IP.  This gets rid of those random ports for local development.  
+It detects the highest used IP address in that range and increase that by 1. That gives you 255 x 255 = 65.025 IP addresses to use.  This means each server can use port 80 since you can bind more than one server to the same port so long as it's a different IP.  This gets rid of those random ports for local development.
 
 Please note, this will NOT work if you have another web server such as Apache that has been configured to listen to port 80 on all IPs ( `*.80` ).  You can troubleshoot what other processes are listening to ports with the `netstat` command.
 ```bash

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Edit your `server.json` to use an array of hostnames.
 	}
 }
 ```
-The module will concert this array into space-delimited list and make a single entry in the hosts file as previously described.
+The module will convert the array to a space-delimited list and update the hosts file as previously described.
 
 ### Location of the hosts file
 


### PR DESCRIPTION
# Requirement

Allow command box to add a single host name alias via CLI or multiple via `server.json`. 

# Update

New setting, `web.hostAlias`, can be either a string or an array.

# Testing

## Adding a single alias via CLI

```bash
server set web.hostAlias=www.myproject.local
```

If `web.host` is not set: 
```bash
Adding host '127.0.0.1 www.myproject.local' to your hosts file!
```

If `web.host` is `myproject.local`:
```bash
Adding host 'myproject.local www.myproject.local' to your hosts file!
```

## Adding multiple aliases via `server.json`
```bash
{
	"web":{
		"host":"myproject.local",
		"hostAlias":[
			"www.myproject.local",
			"portalA.myproject.local",
			"portalB.myproject.local"
		]
	}
}

```

When the server starts:
```bash
Adding host 'myproject.local www.myproject.local portalA.myproject.local portalB.myproject.local' to your hosts file!
```

## Removing hostAlias via CLI

```bash
server clear web.hostAlias
```

If `web.host` is not set when the server starts:
```bash
Adding host '127.0.0.1' to your hosts file!
```

If `web.host` is `myproject.local`:
```bash
Adding host 'myproject.local' to your hosts file!
```

# Hosts file 

The entry will look something like this: 
```bash
127.127.0.36    myproject.local www.myproject.local portalA.myproject.local portalB.myproject.local # CommandBox: Server 7D84EFFAFBFB68CA729BCE0BE34BD129 2018-01-03 17:05:54
```
  