### PR TITLE
Fixing loose host removal regex

### DIFF
--- a/models/HostupdaterService.cfc
+++ b/models/HostupdaterService.cfc
@@ -86,10 +86,12 @@ component accessors="true" singleton {
 	private void function removeOldEntriesFromHostsfile( required string id_or_hostname ){
 
 		if( !variables.fileSystem.isWindows() ) {
-			if( variables.fileSystem.isMac() ) {
-				sudo( "sed -i '' '/.*#arguments.id_or_hostname.replace('.', '\.', 'all')#.*/d' #getHostsFileName()#" );
-			} else {
-				sudo( "sed -i '/.*#arguments.id_or_hostname.replace('.', '\.', 'all')#.*/d' #getHostsFileName()#" );
+			local.sedOptArg = variables.fileSystem.isMac() ? " ''" : ""; 
+			// remove by hostname
+			sudo( "sed -E -i#local.sedOptArg# '/127\.[0-9.]+ +#arguments.id_or_hostname.replace('.', '\.', 'all')# .+/d' #getHostsFileName()#" );
+			// remove by id, if it is very probably an id
+			if (len(arguments.id_or_hostname) gte 32 and refind('[0-9A-Fa-f]{32}', arguments.id_or_hostname) eq 1) {
+				sudo( "sed -i#local.sedOptArg# '/.* #arguments.id_or_hostname# .*/d' #getHostsFileName()#" );
 			}
 		} else {
 			removeMatchingLines( [id_or_hostname] );


### PR DESCRIPTION
Hi, see changes. By adding spaces around the text to match, and a more precise regex, we can make sure we are not removing lines we shouldn't (like removing "www.site.com" when we only wanted to remove "site.com" before adding it)
The server.json config which did not work with the current 1.8.0, is:
`{
    "web":{
        "hostAlias":[
            "beheer.fbc.local",
            "fbc.local"
        ],
        "host":"www.fbc.local"
    }
}`
In the code, the "fbc.local" goes last, and matches on the other 2 subdomains, thus removing them.
