### PR TITLE
Add a filter to remove 'localhost' entries

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -27,7 +27,7 @@ component accessors=true {
 
 		var ary = duplicate( aliases);
 		ary = ary.prepend( hostname )
-					.reduce( function( arr, alias ){
+					.reduce( ( arr, alias ) => {
 					if( alias.reFindNoCase( '[$a-z]') && !arr.find( alias ) ){
 						// [CS] [2018-03-15] if the alias is a system var, use the evaluated value
 						if( left( alias, 1 ) == '$' )
@@ -38,7 +38,8 @@ component accessors=true {
 					}
 
 					return arr;
-					}, [] );
+					}, [] )
+					.filter( ( host ) => host != 'localhost' );
 
 		wirebox.getInstance( 'hostupdaterService@commandbox-hostupdater' ).checkIP( arguments.interceptData.serverDetails.serverInfo.id, ary );
 		


### PR DESCRIPTION
Creating a host entry for localhost doesn't work on Windows and just makes the site inaccessible.   Also, converted the closures to sweet, sweet arrow functions.