### PR TITLE
Revert "Update ModuleConfig.cfc for processing all env vars"

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -6,18 +6,17 @@ component accessors=true {
 
 	
 	public void function preServerStart( interceptData ) {
-		var systemSettings = wirebox.getInstance( 'SystemSettings' );
-		var serverJSON = systemSettings.expandSystemSettings( duplicate( arguments.interceptData.serverDetails.serverJSON ) );
-		
 		var hostname = 	arguments.interceptData.serverProps.host 				  ?: 			// host provided on the command line?
-						serverJSON.web.host ?:			// host provided in server.json?
+						arguments.interceptData.serverDetails.serverJSON.web.host ?:			// host provided in server.json?
 						wirebox.getInstance( 'ServerService' ).getDefaultServerJSON().web.host; // if nothing was provided, use default (127.0.0.1)
 
 		var aliases  =  arguments.interceptData.serverProps.hostAlias					?:		// hostAlias provided on the command line?
-						serverJSON.web.hostAlias 	?:		// hostAlias provided 'web' section of server.json?
-						serverJSON.hostAlias 		?:		// hostAlias provided in server.json?
+						arguments.interceptData.serverDetails.serverJSON.web.hostAlias 	?:		// hostAlias provided 'web' section of server.json?
+						arguments.interceptData.serverDetails.serverJSON.hostAlias 		?:		// hostAlias provided in server.json?
 						[];																		// if nothing was provided, use default (empty array)
 
+		var systemSettings = wirebox.getInstance( 'SystemSettings' );
+		
 		if( !isArray( aliases ))
 			aliases = aliases.listToArray();
 
@@ -26,12 +25,18 @@ component accessors=true {
 		if( !isEmpty( aliases ) )
 			arguments.interceptData.serverDetails.serverJSON["web"]["hostAlias"] = duplicate( aliases );
 
-		var ary = duplicate( aliases );
+		var ary = duplicate( aliases);
 		ary = ary.prepend( hostname )
 					.reduce( function( arr, alias ){
-					if( alias.reFindNoCase( '[a-z]') && !arr.find( alias ) ){
+					if( alias.reFindNoCase( '[$a-z]') && !arr.find( alias ) ){
+						// [CS] [2018-03-15] if the alias is a system var, use the evaluated value
+						if( left( alias, 1 ) == '$' )
+							alias = systemSettings.expandSystemSettings( alias );
+
 						arr.append( alias );
+
 					}
+
 					return arr;
 					}, [] );
 


### PR DESCRIPTION
Reverts chrisschmitz/commandbox-hostupdater#15
Introduced an error 
"Invalid call of the function [expandSystemSettings], first Argument [text] is of invalid type, Cannot cast Object type [Struct] to a value of type [string]"
in the following code: 
line 10:	`var serverJSON = systemSettings.expandSystemSettings( duplicate( arguments.interceptData.serverDetails.serverJSON ) );`