### PR TITLE
Get host updater working on Mac again

### DIFF
--- a/models/HostupdaterService.cfc
+++ b/models/HostupdaterService.cfc
@@ -178,7 +178,7 @@ component accessors="true" singleton {
 	
 	private any function sudo( required string cmdstring ){
 		try {
-			return wb.getinstance( name='CommandDSL', initArguments={ name : "run sudo " & arguments.cmdstring  } )
+			return wb.getinstance( name='CommandDSL', initArguments={ name : 'run sudo sh -c "' & arguments.cmdstring & '"'  } )
 			.run(echo:false);
 			//variables.printBuffer.boldRedLine( arguments.cmdstring ).toConsole();
 		}


### PR DESCRIPTION
I don't have a Windows box to test on, but this is working on the latest macOS.